### PR TITLE
Ranking column header colors matching plot colors

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -17147,9 +17147,9 @@ class ApplicationWindow(QMainWindow):
         return ('{0:.0f}'.format(aw.qmc.convertTemp(data[key],unit,aw.qmc.mode)) + aw.qmc.mode if key in data else "")
     
             
-    def rankingData2htmlentry(self,production_data,ranking_data):
+    def rankingData2htmlentry(self,production_data,ranking_data,plot_color=None):
         HTML_REPORT_TEMPLATE = u("""<tr>
-<td>$batch</td>
+<td$color_code>$batch</td>
 <td>$time</td>
 <td>$title</td>
 <td sorttable_customkey=\"$in_num\">$weightin</td>
@@ -17168,7 +17168,13 @@ class ApplicationWindow(QMainWindow):
 </tr>""")
         pd = self.productionData2string(production_data)
         rd = self.rankingData2string(ranking_data)
+        batch_td_color = u("")
+        if plot_color is not None:
+            batch_color = [x * 100 for x in plot_color[0:3]]
+            batch_color.append(0.7)
+            batch_td_color = unicode(' style="background-color: rgba(' + '%,'.join(map(str, batch_color)) + ')"')
         return libstring.Template(HTML_REPORT_TEMPLATE).safe_substitute(
+            color_code = batch_td_color,
             batch = pd["id"],
             time = pd["time"],
             title = pd["title"],
@@ -17277,7 +17283,6 @@ class ApplicationWindow(QMainWindow):
                 pd = self.profileProductionData(p,c)
                 c += 1
                 rd = self.profileRankingData(p)
-                entries += self.rankingData2htmlentry(pd,rd) + "\n"
                 i = aw.convertWeight(pd["weight"][0],aw.qmc.weight_units.index(pd["weight"][2]),aw.qmc.weight_units.index(aw.qmc.weight[2]))
                 o = aw.convertWeight(pd["weight"][1],aw.qmc.weight_units.index(pd["weight"][2]),aw.qmc.weight_units.index(aw.qmc.weight[2]))
                 if i > 0:
@@ -17320,8 +17325,12 @@ class ApplicationWindow(QMainWindow):
                     cuppings += rd["cupping"]
                     cuppings_count += 1
                 # add BT curve to graph
-                if len(profiles) < 11:
+                if len(profiles) >= 11:
+                    entries += self.rankingData2htmlentry(pd,rd) + "\n"
+                else:
                     try:
+                        cl = next(color)
+                        entries += self.rankingData2htmlentry(pd,rd, cl) + "\n"
                         label = ((u(pd["batchprefix"]) + u(pd["batchnr"])) if pd["batchnr"] > 0 else u(""))
                         temp = [aw.qmc.convertTemp(t,rd["temp_unit"],self.qmc.mode) for t in rd["temp"]]
                         timex = rd["timex"]
@@ -17350,7 +17359,6 @@ class ApplicationWindow(QMainWindow):
                         min_start_time = min(min_start_time,timex[charge])
                         max_end_time = max(max_end_time,timex[drop])
                         # cut-out only CHARGE to DROP
-                        cl = next(color)
                         self.l_temp, = self.qmc.ax.plot(timex,stemp,markersize=self.qmc.BTmarkersize,marker=self.qmc.BTmarker,
                                 sketch_params=None,path_effects=[PathEffects.withStroke(linewidth=self.qmc.BTlinewidth+aw.qmc.patheffects,foreground="w")],
                                 linewidth=self.qmc.BTlinewidth,linestyle=self.qmc.BTlinestyle,drawstyle=self.qmc.BTdrawstyle,color=cl,label=label)


### PR DESCRIPTION
For the Report>Ranking>Web...

When plotting, gives the header column the same color as the corresponding graph.
I found this incredibly useful when adding multiple batches to the ranking report and comparing the plots to the table data (after changing default sorting).

Note: To emulate the slightly blurred line colors of matplotlib, opacity is set to 0.7 in the CSS code.