### PR TITLE
Allow external program arguments and expand initial ~

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -30301,15 +30301,14 @@ class serialport(object):
                 startupinfo.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
                 startupinfo.wShowWindow = subprocess.SW_HIDE
             
-            cmd_str = os.path.expanduser(aw.ser.externalprogram)
             if platf == 'Windows':
+                cmd_str = os.path.expanduser(aw.ser.externalprogram)
                 if sys.version < '3':
                     import locale
                     cmd_str = cmd_str.encode(locale.getpreferredencoding())
                 p = subprocess.Popen(cmd_str,env=my_env,stdout=subprocess.PIPE,startupinfo=startupinfo,shell=True)
             else:
-#                p = subprocess.Popen(shlex.split(cmd_str),env=my_env,stdout=subprocess.PIPE,startupinfo=startupinfo)
-                p = subprocess.Popen(cmd_str,env=my_env,stdout=subprocess.PIPE,startupinfo=startupinfo)
+                p = subprocess.Popen([os.path.expanduser(c) for c in shlex.split(aw.ser.externalprogram)],env=my_env,stdout=subprocess.PIPE,startupinfo=startupinfo)
             output = p.communicate()[0].decode('UTF-8')
             
             tx = aw.qmc.timeclock.elapsed()/1000.


### PR DESCRIPTION
Allows external program devices command to pass arguments (not working since 2016-11-19).

Also expands initial ~ and ~user.