### PR TITLE
Cleanup PL125-T4 Code

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -33629,11 +33629,6 @@ class serialport(object):
                     T2 = hex2int(r[25],r[24])/10.# select byte 25 and 24
                     aw.qmc.extraPL125T4T4 = hex2int(r[21],r[20])/10.# select byte 21 and 20
                     aw.qmc.extraPL125T4T3 = hex2int(r[19],r[18])/10. # select byte 19 and 18
-#                    bla = open("/tmp/blubb.log","a")
-#                    bla.write(str(T1)+" "+str(T2)+" "+str(aw.qmc.extraPL125T4T3)+" "+str(aw.qmc.extraPL125T4T4))
-#                    bla.write("\n")
-#                    bla.flush()
-#                    bla.close()
                     return T1,T2
                 else:
                     if retry:

--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -38823,15 +38823,6 @@ class DeviceAssignmentDlg(ArtisanDialog):
                     aw.ser.stopbits = 1
                     aw.ser.timeout = 1.0
                     message = QApplication.translate("Message","Device set to {0}. Now, chose serial port", None).format(meter)
-                elif meter == "VOLTCRAFT PL-125-T4":
-                    aw.qmc.device = 67
-                    #aw.ser.comport = "COM4"
-                    aw.ser.baudrate = 9600
-                    aw.ser.bytesize = 8
-                    aw.ser.parity= 'N'
-                    aw.ser.stopbits = 1
-                    aw.ser.timeout = 1.0
-                    message = QApplication.translate("Message","Device set to {0}. Now, chose serial port", None).format(meter)
                 elif meter == "VOLTCRAFT 300K":
                     aw.qmc.device = 13
                     #aw.ser.comport = "COM4"


### PR DESCRIPTION
Sorry, I forgot to delete these testing/debugging lines. Additionally you added another elif meter == "VOLTCRAFT PL-125-T4" in d9567a20e60090be2e9cdca97a9211d232093180 and forgot to delete the old one (which is somehow pointing to device 67 instead of 77?). 

I tested it and now it works again after these two commits :+1: 