### PR TITLE
Better error message when trying to install on 32bit windows.

### DIFF
--- a/src/setup-install3-pi.nsi
+++ b/src/setup-install3-pi.nsi
@@ -143,7 +143,7 @@ Function .onInit
     IDOK uninst
     Abort
   ${Else}
-    MessageBox MB_OK "x64 test only"
+    MessageBox MB_OK "You are not using a 64bit system.\nSorry, we can not install Artisan on your system."
     Abort
   ${EndIf}
  


### PR DESCRIPTION
Instead of an ambiguous "x64 test only", better to give a useful user facing message.