### PR TITLE
IO COMMANDs feedback state in the GUI 

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -10267,7 +10267,7 @@ class SampleThread(QThread):
             d = aw.qmc.delay / 1000.
             tx_org = tx[-l:] # as len(tx)=len(temp) here, it is guranteed that len(tx_org)=l
             # we create a linearly spaced time array starting from the newest timestamp in sampling interval distance
-            tx_lin = numpy.flip(numpy.arange(tx_org[-1],tx_org[-1]-l*d,-d)) # by contruction, len(tx_lin)=len(tx_org)=l
+            tx_lin = numpy.flip(numpy.arange(tx_org[-1],tx_org[-1]-l*d,-d), axis=0) # by contruction, len(tx_lin)=len(tx_org)=l
             temp_trail = temp[-l:] # by construction, len(temp_trail)=len(tx_lin)=len(tx_org)=l
             temp_trail_re = numpy.interp(tx_lin, tx_org, temp_trail) # resample data into that linear spaced time
             return numpy.average(temp_trail_re[-len(decay_weights):],weights=decay_weights[-l:])  # len(decay_weights)>len(temp_trail_re)=l is possible

--- a/src/artisanlib/sliderStyle-wide.py
+++ b/src/artisanlib/sliderStyle-wide.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+artisan_slider_style = """
+            QSlider::groove:vertical {{
+                background: #ddd;
+                border: 0.5px solid #aaa;
+                width: 10px;
+                border-radius: 5px;
+            }}
+            QSlider::sub-page:vertical {{
+                background: #ddd;
+                border: 0.5px solid #aaa;
+                width: 85px;
+                border-radius: 5px;
+            }}
+            QSlider::add-page:vertical {{
+                background: {color};
+                border: 1px solid {color};
+                width: 5px;
+                border-radius: 2px;
+            }}
+            QSlider::handle:vertical {{
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #fff, stop:1 #eee);
+                border: 0.5px solid #ddd;
+                height: 10px;
+                margin-top: -1px;
+                margin-bottom: -1px;
+                margin-left: -15px;
+                margin-right: -15px;
+                border-radius: 5px;
+            }}
+            QSlider::handle:vertical:hover {{
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #eee, stop:1 #ccc);
+                border: 1px solid #ccc;
+                border-radius: 5px;
+            }}
+            QSlider::sub-page:vertical:disabled {{
+                background: #bbb;
+                border-color: #999;
+            }}
+            QSlider::add-page:vertical:disabled {{
+                background: #eee;
+                border-color: #999;
+            }}
+            QSlider::handle:vertical:disabled {{
+                background: #eee;
+                border: 1px solid #aaa;
+                border-radius: 5px;
+            }}
+"""
+

--- a/src/artisanlib/sliderStyle.py
+++ b/src/artisanlib/sliderStyle.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+artisan_slider_style = """
+            QSlider::groove:vertical {{
+                background: #ddd;
+                border: 0.5px solid #aaa;
+                width: 3px;
+                border-radius: 5px;
+            }}
+            QSlider::sub-page:vertical {{
+                background: #ddd;
+                border: 0.5px solid #aaa;
+                width: 85px;
+                border-radius: 5px;
+            }}
+            QSlider::add-page:vertical {{
+                background: {color};
+                border: 1px solid {color};
+                width: 5px;
+                border-radius: 2px;
+            }}
+            QSlider::handle:vertical {{
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #fff, stop:1 #eee);
+                border: 0.5px solid #ddd;
+                height: 8px;
+                margin-top: -1px;
+                margin-bottom: -1px;
+                margin-left: -10px;
+                margin-right: -10px;
+                border-radius: 5px;
+            }}
+            QSlider::handle:vertical:hover {{
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #eee, stop:1 #ccc);
+                border: 1px solid #ccc;
+                border-radius: 5px;
+            }}
+            QSlider::sub-page:vertical:disabled {{
+                background: #bbb;
+                border-color: #999;
+            }}
+            QSlider::add-page:vertical:disabled {{
+                background: #eee;
+                border-color: #999;
+            }}
+            QSlider::handle:vertical:disabled {{
+                background: #eee;
+                border: 1px solid #aaa;
+                border-radius: 5px;
+            }}
+"""


### PR DESCRIPTION
I made a few changes so the gui can give better feedback about the state of the commands it has sent to the connected phidgets output devices.  In this code, toggle() now updates the button style to indicate the state of the digital output, and a new command button() updates the style of a given button (not necessarily the one that was pressed) to indicate the state of a digital output, and slider() updates a slider position. 

I also added input devices slider_01 and slider_23 to get the slider positions for plotting and csv output. In my case the sliders are controlling analog voltages, which control the motors and the modulating gas valve and wanted a graphical record of slider positions saved to the graph and csv output.

Since I am doing a lot of control with the sliders, I found it helpful to make them bigger. To make it easier for any user to configure the slider stylesheet, I moved this into its own file that gets included. 