### PR TITLE
Add instructions for installing via Homebrew package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you think Artisan is useful to you, contribute financially to its further dev
 <img src="https://github.com/MAKOMO/artisan/blob/master/wiki/screenshots/artisan-cover.png?raw" width="700">
 -->
 
-[Download](https://github.com/MAKOMO/artisan/releases/latest) (Mac/Windows/Linux)
+[Download](https://github.com/MAKOMO/artisan/releases/latest) (macOS/Windows/Linux)
 
 [Installation Instructions](https://github.com/artisan-roaster-scope/artisan/blob/master/wiki/Installation.md)
 

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -10,7 +10,8 @@ Verify that your roasting machine and the devices you plan to operate with Artis
 
 Find and download the package of the latest release for your platform. The filenames are as follows, with `x.x.x` the version number.
 
-* OS X: `artisan-mac-x.x.x.dmg`
+* macOS: `artisan-mac-x.x.x.dmg`
+  * Artisan is also available via the [Homebrew Cask](https://github.com/Homebrew/homebrew-cask) package manager. See below for instructions.
 * Windows: `artisan-win-x.x.x.zip`
 * Linux Redhat/CentOS: `artisan-linux-x.x.x.rpm`
 * Linux Debian/Ubuntu: `artisan-linux-x.x.x.deb`
@@ -22,11 +23,21 @@ Find and download the package of the latest release for your platform. The filen
 
 Extract the downloaded zip archive and start the included installer.
 
-### Mac OS X
+### macOS
 
 Mount the installation `.dmg` archive with a double-click and drag the contained `Artisan.app` to your `Applications` folder
 
 You need to (temporarily during installation) tick "Allow applications downloaded from Anywhere" in the Security & Privacy Preference Panel to start the app. On first app start Mac OS X can warn about unidentified developer. See https://support.apple.com/kb/PH21769 on how to open an app from an unidentified developer. After first application start, tick again "Allow applications downloaded from Anywhere" in the Security & Privacy Preference Panel.
+
+#### Alternative: Homebrew
+Artisan is available on [Homebrew](https://brew.sh/). To install Homebrew:
+```
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+To install Artisan via Homebrew:
+```
+brew cask install artisan
+```
 
 ### Linux
 


### PR DESCRIPTION
I recently added Artisan to the Homebrew package manager for macOS: https://github.com/Homebrew/homebrew-cask/pull/69822

I thought it might be worth mentioning this installation option directly in the Artisan documentation, since Homebrew is a very popular tool.

Also, since 2016 with the release of 10.12 Sierra, the Apple operating system has been known as "macOS". It hasn't been known as "Mac OS X" since 2012 with the release of [OS X 10.8 Mountain Lion](https://en.wikipedia.org/wiki/MacOS#OS_X). The Artisan website and documentation still seem to use "Mac OS X" everywhere: https://artisan-scope.org/about/#Platforms