### PR TITLE
build-linux-pkg.sh: Migrate from sudo to fakeroot

### DIFF
--- a/src/build-linux-pkg.sh
+++ b/src/build-linux-pkg.sh
@@ -21,9 +21,9 @@ rm -rf debian/usr/share/artisan
 tar -xf dist-centos64.tar -C debian/usr/share
 mv debian/usr/share/dist debian/usr/share/artisan
 find debian -name .svn -exec rm -rf {} \; > /dev/null 2>&1
-sudo chown -R root:root debian
-sudo chmod -R go-w debian
-sudo chmod 0644 debian/usr/share/artisan/*.so*
+fakeroot chown -R root:root debian
+fakeroot chmod -R go-w debian
+fakeroot chmod 0644 debian/usr/share/artisan/*.so*
 rm -f ${NAME}*.rpm
 
 cd debian
@@ -52,7 +52,7 @@ flavor." \
 -v ${VERSION} --prefix / usr etc
 
 # Allow FPM to write some temporary files
-sudo chmod o+w .
+fakeroot chmod o+w .
 fpm --deb-no-default-config-files -s dir -t deb -n artisan --license GPL3 -m "Marko Luther <marko.luther@gmx.net>" -p .. \
 --vendor "Artisan GitHub" \
 --no-auto-depends \


### PR DESCRIPTION
For every use of sudo in this script we can in fact use sudo. None of
these sudo wrappered commands really require root and best practice is
to fake it.

The default user permissions on Debian do not add the user to the
sudoers group. fakeroot is the right way to do this.

Signed-off-by: Bryan O'Donoghue <bryan.odonoghue@nexus-software.ie>