### PR TITLE
Add "Plug-and-Play Data Dome" to machine list

### DIFF
--- a/src/includes/Machines/Hive Roaster/Plug-and-Play Data Dome.aset
+++ b/src/includes/Machines/Hive Roaster/Plug-and-Play Data Dome.aset
@@ -1,0 +1,5 @@
+[Device]
+id=52
+
+[RoastProperties]
+roastertype=Hive Roaster Plug-and-Play Data Dome


### PR DESCRIPTION
Adds "trivial" support for Hive Roaster and "Data Dome" to Artisan. Data dome simply uses a phidget 1051, but this will make it easy for those who may be unfamiliar with the inner workings of the setup process (though it may be trivial). 

https://hiveroaster.com/collections/frontpage/products/cascabel-with-thermocouple-the-data-dome-plug-and-play

Was looking to update the supported device list too, but that seems to be maintained elsewhere.

Please let me know if I missed anything, would be happy to fix it! 