### PR TITLE
Added command_utility to perform commandline utility tasks 

### DIFF
--- a/src/artisan.pro
+++ b/src/artisan.pro
@@ -46,6 +46,7 @@ SOURCES = \
     artisanlib/statistics.py \
     artisanlib/transposer.py \
     artisanlib/wheels.py \
+    artisanlib/command_utility.py \
     const/UIconst.py \
     help/alarms_help.py \
     help/autosave_help.py \

--- a/src/artisan.py
+++ b/src/artisan.py
@@ -67,6 +67,7 @@ else: # Linux
         pass
         
 from artisanlib import main
+from artisanlib import main, command_utility
 #import numpy # @UnusedImport # what this for!?
 from multiprocessing import freeze_support
 
@@ -80,14 +81,17 @@ if system() == "Windows" and (hasattr(sys, "frozen") # new py2exe
     del executable
 
 if __name__ == '__main__':
-    freeze_support()
-    if os.environ.get('TRAVIS'):
-        # Hack to exit inside Travis CI
-        # Ideally we would use pytest-qt.
-        import threading
-        t = threading.Timer(30, lambda: os._exit(0))
-        t.start()
-    main.main()
+
+    # Manange Commands that does not need to start the whole Application
+    if command_utility.handleCommands() == True:
+        freeze_support()
+        if os.environ.get('TRAVIS'):
+            # Hack to exit inside Travis CI
+            # Ideally we would use pytest-qt.
+            import threading
+            t = threading.Timer(30, lambda: os._exit(0))
+            t.start()
+        main.main()
 
 
 # EOF

--- a/src/artisanlib/command_utility.py
+++ b/src/artisanlib/command_utility.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# ABOUT
+# Handeling of Commandline Utility Functions
+
+# LICENSE
+# This program or module is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, either version 2 of the License, or
+# version 3 of the License, or (at your option) any later versison. It is
+# provided for educational purposes and is distributed in the hope that
+# it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+# the GNU General Public License for more details.
+
+# AUTHOR
+# FilePhil, 2020
+
+from artisanlib import __version__
+import sys
+
+def handleCommands():
+    """ Handles incoming commands and decides on an action.
+
+    args -- given command line arguments
+    return -- if the action requires the application, return true
+    """
+
+    for arg in sys.argv:
+
+        if arg in ('-v', '--Version'):
+            print ('Artisan  Verison {}'.format(__version__))
+
+            return False
+
+        if arg in ('-h', '--Help'):
+            # To write a text that is not indented
+            # the text must be written like this
+            helpText ="""
+Artisan  Verison {}
+
+Usage:
+artsian
+artsian [options] [path ...]
+
+
+One path to a file may be specified. If there is an
+existing Artisan window the path will be opened in the
+viewer mode.
+
+Options:
+    -h, --help    Show help
+    -v, --Version Show version number
+"""
+
+            print(helpText)
+            return False
+
+    return True


### PR DESCRIPTION
According to the Issue #540 I added a small function to  print the version and a help text for the command line interface without opening the whole application.
I placed the function in a separate file to have fast overview and not to bury it in the main.py