### PR TITLE
Add AppImage to CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -172,6 +172,7 @@ for:
     - export UPLOADTOOL_ISPRERELEASE=true
     - bash upload.sh artisan-*.deb
     - bash upload.sh artisan-*.rpm
+    - bash upload.sh artisan-*.AppImage
 
 -
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,9 +18,7 @@ environment:
 #  - job_name: rpi
 #    appveyor_build_worker_image: Ubuntu1604
 
-  GITHUB_TOKEN:
-     secure: PlbRv5ROUa2qrP6YTVZhC5xpnCEF5cbQ4YuW3Hm6I3gvVBQPTybAvI0ZgLA1P6AL
-  
+
 matrix:
   allow_failures:
     - job_name: rpi
@@ -32,8 +30,8 @@ init:
 
 branches:
   only:
-    - master     
-        
+    - master
+
 stack:
   python 3.8
 
@@ -125,10 +123,10 @@ for:
     - .ci/install-${ARTISAN_OS}.sh
 
   build_script:
-    - echo "MacOS Build"  
+    - echo "MacOS Build"
     - chmod +x src/*.sh
     - .ci/script-${ARTISAN_OS}.sh
-    
+
 #  artifacts:
 #    - path: 'src/artisan-*.dmg'
 
@@ -150,14 +148,14 @@ for:
     PYTHON: $HOME/venv3.8
 
   install:
-    - echo "Linux Install"  
+    - echo "Linux Install"
     - chmod +x .ci/*.sh
     - export GIT_VERSION=`git rev-parse --verify --short HEAD 2>/dev/null|| echo "???"`
     - sed -i'' -e "s/__revision__ = '0'/__revision__ = '$GIT_VERSION'/" src/artisanlib/__init__.py
     - .ci/install-${ARTISAN_OS}.sh
 
   build_script:
-    - echo "Linux Build"  
+    - echo "Linux Build"
     - chmod +x src/*.sh
     - .ci/script-${ARTISAN_OS}.sh
 
@@ -185,14 +183,14 @@ for:
     PYTHON: $HOME/venv3.8
 
   install:
-    - echo "RPI Install"  
+    - echo "RPI Install"
     - chmod +x ./.ci/*.sh
     - export GIT_VERSION=`git rev-parse --verify --short HEAD 2>/dev/null|| echo "???"`
     - sed -i'' -e "s/__revision__ = '0'/__revision__ = '$GIT_VERSION'/" src/artisanlib/__init__.py
     - .ci/install-${ARTISAN_OS}.sh
 
   build_script:
-    - echo "RPI Build"  
+    - echo "RPI Build"
     - chmod +x src/*.sh
     - .ci/script-${ARTISAN_OS}.sh
 

--- a/src/artisan-AppImage.yml
+++ b/src/artisan-AppImage.yml
@@ -1,0 +1,15 @@
+app: artisan
+
+ingredients:
+  dist: trusty
+  sources:
+    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
+  script:
+    - oDir=$(pwd)
+    - cd ..
+    - path="file://$(pwd)/$(ls artisan-*.deb)" # Serach for the package
+    - cd $oDir # go back to orignal folder
+    - curl -O -C - $path  # use the deb package
+script:
+  - rm -rf "./usr/bin"
+  - mv "./usr/share/artisan" "./usr/bin"

--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -23715,7 +23715,7 @@ class ApplicationWindow(QMainWindow):
     def ArtisanOpenFilesDialog(self,msg=QApplication.translate("Message","Select",None),ext="*",path=None):
         if path is None:
             path = self.getDefaultPath()
-        res = QFileDialog.getOpenFileNames(self,msg,path,ext)[0]
+        res = QFileDialog.getOpenFileNames(self,msg,path,ext, options=QFileDialog.DontUseNativeDialog)[0]
         for f in res:
             self.setDefaultPath(str(f))
         return res
@@ -23727,7 +23727,7 @@ class ApplicationWindow(QMainWindow):
     def ArtisanOpenFileDialog(self,msg=QApplication.translate("Message","Open",None),ext="*",ext_alt=None,path=None):
         if path is None:
             path = self.getDefaultPath()
-        f = str(QFileDialog.getOpenFileName(self,caption=msg,directory=path,filter=ext)[0])
+        f = str(QFileDialog.getOpenFileName(self,caption=msg,directory=path,filter=ext, options=QFileDialog.DontUseNativeDialog)[0])
         if ext_alt is not None and not f.endswith(ext_alt):
             return ""
         else:
@@ -23758,7 +23758,7 @@ class ApplicationWindow(QMainWindow):
     def ArtisanSaveFileDialog(self,msg=QApplication.translate("Message","Save",None),ext="*.alog",path=None):
         if path is None:
             path = self.getDefaultPath()
-        f = str(QFileDialog.getSaveFileName(self,msg,path,ext)[0])
+        f = str(QFileDialog.getSaveFileName(self,msg,path,ext, options=QFileDialog.DontUseNativeDialog)[0])
         self.setDefaultPath(f)
         return f
 
@@ -32664,7 +32664,8 @@ class ApplicationWindow(QMainWindow):
         initialPath = QDir.currentPath() + "/ArtisanScreenshot." + fmt
         fileName = QFileDialog.getSaveFileName(self, "Artisan ScreenShot",
                 initialPath,
-                "%s Files (*.%s);;All Files (*)"%(fmt.upper(),fmt))[0]
+                "%s Files (*.%s);;All Files (*)"%(fmt.upper(),fmt),
+                options=QFileDialog.DontUseNativeDialog)[0]
         if fileName:
             imag.save(fileName, fmt)
 
@@ -32675,7 +32676,8 @@ class ApplicationWindow(QMainWindow):
         initialPath = QDir.currentPath() + "/DesktopScreenshot." + fmt
         fileName = QFileDialog.getSaveFileName(self, "Desktop ScreenShot",
                 initialPath,
-                "%s Files (*.%s);;All Files (*)"%(fmt.upper(),fmt))[0]
+                "%s Files (*.%s);;All Files (*)"%(fmt.upper(),fmt),
+                options=QFileDialog.DontUseNativeDialog)[0]
         if fileName:
             imag.save(fileName, fmt)
 

--- a/src/build-linux-pkg.sh
+++ b/src/build-linux-pkg.sh
@@ -73,4 +73,13 @@ flavor." \
 cd ..
 mv *.rpm ${NAME}.rpm
 mv *.deb ${NAME}.deb
+
+# Create AppImage by using the pkg2appimage tool
+wget -c https://github.com/$(wget -q https://github.com/AppImage/pkg2appimage/releases -O - | grep "pkg2appimage-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+chmod +x ./pkg2appimage-*.AppImage
+./pkg2appimage-*.AppImage artisan-AppImage.yml
+
+mv ./out/*.AppImage ${NAME}.AppImage
+
+
 ls -lh *.deb *.rpm


### PR DESCRIPTION
Related to #557 
These Changes enabling it build a AppImage of Artisan in the CI Solution.

To use the Appveyor on Forks it is necessary to delete the GITHUB_TOKEN from the **.appveyor.yml**  and add it in the settings to the Environment variables of Appveyor.

