### PR TITLE
Removes artisanviewer_first_start global

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -15391,7 +15391,6 @@ class MyQDoubleValidator(QDoubleValidator):
 ########################################################################################
 
 aw = None # assigned to the single instance of ApplicationWindow on creation
-artisanviewerFirstStart = False
 
 class ApplicationWindow(QMainWindow):
     global app # pylint: disable=global-statement
@@ -15413,10 +15412,11 @@ class ApplicationWindow(QMainWindow):
     updateSerialLogSignal = pyqtSignal()
     fireslideractionSignal = pyqtSignal(int)
 
-    def __init__(self, parent = None, *, locale):
+    def __init__(self, parent = None, *, locale, artisanviewer_first_start):
 
         self.locale = locale
         self.app = app
+        self.artisanviewer_first_start = artisanviewer_first_start
         self.superusermode = False
 
 #PLUS
@@ -18286,7 +18286,7 @@ class ApplicationWindow(QMainWindow):
             QMessageBox.information(aw,QApplication.translate("Message","One time message about loading settings at start-up", None),string)
 
         # provide information message to user about ArtisanViewer the first time it is started
-        if artisanviewerFirstStart:
+        if self.artisanviewer_first_start:
             string =  QApplication.translate("Message","Welcome to the ArtisanViewer!", None).format(__version__) + "\n\n"
             string += QApplication.translate("Message","This is a one time message to introduce you to the ArtisanViewer.", None) + "\n\n"
             string += QApplication.translate("Message","The ArtisanViewer opens whenever a copy of Artisan is already running.", None) + "\n\n"
@@ -37318,8 +37318,9 @@ def initialize_locale(my_app):
 
 
 def main():
-    global aw, app, artisanviewerFirstStart # pylint: disable=global-statement
+    global aw, app # pylint: disable=global-statement
 
+    artisanviewer_first_start = False
     locale = initialize_locale(app)
 
     # supress all Qt messages
@@ -37332,12 +37333,15 @@ def main():
         app.setApplicationName("ArtisanViewer")     #needed by QSettings() to store windows geometry in operating system
         viewersettings = QSettings()
         if not viewersettings.contains("Mode"):
-            artisanviewerFirstStart = True
+            artisanviewer_first_start = True
         del viewersettings
 
     aw = None # this is to ensure that the variable aw is already defined during application initialization
 
-    aw = ApplicationWindow(locale=locale)
+    aw = ApplicationWindow(
+        locale=locale,
+        artisanviewer_first_start=artisanviewer_first_start
+    )
 
     app.setActivationWindow(aw,activateOnMessage=False) # set the activation window for the QtSingleApplication
 

--- a/src/test/artisanlib/test_main.py
+++ b/src/test/artisanlib/test_main.py
@@ -1,8 +1,10 @@
-# from test.plugins import ArtisanTestCase
-import unittest
-from test import plugins
+import threading
 
-from artisanlib.main import Artisan, app
+from PyQt5.QtWidgets import QApplication, QMessageBox
+
+from artisanlib.main import Artisan, app, ApplicationWindow
+
+from test import plugins
 
 
 class ArtisanTest(plugins.ArtisanTestCase):
@@ -16,3 +18,49 @@ class ArtisanTest(plugins.ArtisanTestCase):
         # the moment. Probably because you have 2 instances of the
         # QT app running at the same time.
         self.assertIsInstance(app, Artisan)
+
+
+class ApplicationWindowTest(plugins.ArtisanTestCase):
+    """
+    Verify ApplicationWindowTest behaviours.
+    """
+
+    def test_artisanviewer_first_start_message_box(self):
+        """
+        A message box is displayed on when artisanviewer_first_start parameter
+        is passed.
+        """
+
+        result_object = {
+            "exception": None,
+        }
+
+        arguments = {
+            'locale': 'en',
+            'artisanviewer_first_start': True,
+        }
+
+        def thread_target(results, aw_kwargs):
+            try:
+                ApplicationWindow(**aw_kwargs)
+            except Exception as exc:
+                results["exception"] = exc
+
+        t = threading.Thread(target=thread_target, args=(result_object, arguments))
+        t.start()
+
+        while (
+                QApplication.activeModalWidget() is None
+                and result_object["exception"] is None
+        ):
+            pass
+
+        if result_object["exception"]:
+            raise result_object["exception"]
+
+        msg_box = QApplication.activeModalWidget()
+        self.assertIsInstance(msg_box, QMessageBox)
+
+        msg_box.done(1)
+
+        t.join()


### PR DESCRIPTION
This PR removes the `artisanviewerFirstStart` global variable in `main.py` and replaces it with an instance variable used in ApplicationWindow.

I'm also writing a test to check that this variable is used as expected.

coverage report

```bash
QT_QPA_PLATFORM=offscreen coverage run -m unittest discover -s src
coverage report
```

```
Name                                    Stmts   Miss  Cover
-----------------------------------------------------------
src/artisanlib/__init__.py                  6      0   100%
src/artisanlib/aillio.py                  534    467    13%
src/artisanlib/alarms.py                  808    749     7%
src/artisanlib/arabic_reshaper.py         160    132    18%
src/artisanlib/autosave.py                138    119    14%
src/artisanlib/axis.py                    529    490     7%
src/artisanlib/background.py              648    592     9%
src/artisanlib/batches.py                  93     82    12%
src/artisanlib/calculator.py              255    228    11%
src/artisanlib/colors.py                  854    822     4%
src/artisanlib/comm.py                   4357   3916    10%
src/artisanlib/comparator.py             1153   1050     9%
src/artisanlib/cropster.py                362    356     2%
src/artisanlib/cup_profile.py             245    214    13%
src/artisanlib/curves.py                 2148   1967     8%
src/artisanlib/designer.py                559    532     5%
src/artisanlib/devices.py                2187   2098     4%
src/artisanlib/dialogs.py                 149    118    21%
src/artisanlib/events.py                 2629   2450     7%
src/artisanlib/giesen.py                  137    131     4%
src/artisanlib/ikawa.py                   151    142     6%
src/artisanlib/large_lcds.py              592    524    11%
src/artisanlib/logs.py                     78     59    24%
src/artisanlib/main.py                  26898  22679    16%
src/artisanlib/modbusport.py              594    511    14%
src/artisanlib/petroncini.py              121    113     7%
src/artisanlib/phases.py                  289    254    12%
src/artisanlib/phidgets.py                155    138    11%
src/artisanlib/pid.py                     137     89    35%
src/artisanlib/pid_control.py            1138    999    12%
src/artisanlib/pid_dialogs.py            3270   3058     6%
src/artisanlib/platform.py                 45     38    16%
src/artisanlib/ports.py                  1530   1463     4%
src/artisanlib/qcheckcombobox.py          212    181    15%
src/artisanlib/qtsingleapplication.py      91     48    47%
src/artisanlib/roast_properties.py       3901   3557     9%
src/artisanlib/roastlog.py                175    166     5%
src/artisanlib/roastpath.py               237    227     4%
src/artisanlib/rubase.py                  169    164     3%
src/artisanlib/s7port.py                  508    428    16%
src/artisanlib/sampling.py                 73     62    15%
src/artisanlib/simulator.py                52     46    12%
src/artisanlib/sliderStyle.py               1      0   100%
src/artisanlib/statistics.py              223    204     9%
src/artisanlib/suppress_errors.py          19      2    89%
src/artisanlib/time.py                     14      2    86%
src/artisanlib/transposer.py              811    739     9%
src/artisanlib/util.py                    180    126    30%
src/artisanlib/wheels.py                  507    438    14%
src/artisanlib/widgets.py                 153     92    40%
src/artisanlib/wsport.py                  227    165    27%
src/const/UIconst.py                      150      2    99%
src/const/__init__.py                       0      0   100%
src/help/__init__.py                        0      0   100%
src/help/alarms_help.py                    83     79     5%
src/help/autosave_help.py                 126    122     3%
src/help/energy_help.py                    74     70     5%
src/help/eventannotations_help.py          70     66     6%
src/help/eventbuttons_help.py             156    152     3%
src/help/eventsliders_help.py             141    137     3%
src/help/keyboardshortcuts_help.py         43     39     9%
src/help/modbus_help.py                    27     23    15%
src/help/programs_help.py                  23     19    17%
src/help/s7_help.py                        26     22    15%
src/help/symbolic_help.py                 164    160     2%
src/help/transposer_help.py                33     29    12%
src/plus/__init__.py                        1      0   100%
src/plus/account.py                        72     57    21%
src/plus/config.py                         54      2    96%
src/plus/connection.py                    216    188    13%
src/plus/controller.py                    190    169    11%
src/plus/queue.py                         148    124    16%
src/plus/register.py                      129    113    12%
src/plus/roast.py                         202    191     5%
src/plus/stock.py                         692    638     8%
src/plus/sync.py                          469    437     7%
src/plus/util.py                          227    162    29%
src/uic/EnergyWidget.py                   940    935     1%
src/uic/MeasureDialog.py                  165    161     2%
src/uic/SetupWidget.py                    149    145     3%
-----------------------------------------------------------
TOTAL                                   65272  57469    12%
```