### PR TITLE
ModbusTCP timeout settable from Config>Port dialog

### DIFF
--- a/src/artisanlib/modbusport.py
+++ b/src/artisanlib/modbusport.py
@@ -266,7 +266,7 @@ class modbusport():
                                 retry_on_invalid=False, # only supported for serial clients in v2.5.2
                                 reset_socket=self.reset_socket,
                                 retries=1,
-                                timeout=min((self.aw.qmc.delay/2000), 0.2) # the timeout should not be larger than half of the sampling interval
+                                timeout=min((self.aw.qmc.delay/2000), self.timeout) # the timeout should not be larger than half of the sampling interval
                                 )
                         self.readRetries = 1
                     except Exception: # pylint: disable=broad-except
@@ -284,7 +284,7 @@ class modbusport():
                             retry_on_invalid=False, # only supported for serial clients in v2.5.2
                             reset_socket=self.reset_socket,
                             retries=1,
-                            timeout=min((self.aw.qmc.delay/2000), 0.2) # the timeout should not be larger than half of the sampling interval
+                            timeout=min((self.aw.qmc.delay/2000), self.timeout) # the timeout should not be larger than half of the sampling interval
                             )
                         self.readRetries = 1
                     except Exception: # pylint: disable=broad-except # older versions of pymodbus don't support the retries, timeout nor the retry_on_empty arguments

--- a/src/artisanlib/modbusport.py
+++ b/src/artisanlib/modbusport.py
@@ -266,7 +266,7 @@ class modbusport():
                                 retry_on_invalid=False, # only supported for serial clients in v2.5.2
                                 reset_socket=self.reset_socket,
                                 retries=1,
-                                timeout=min((self.aw.qmc.delay/2000), self.timeout) # the timeout should not be larger than half of the sampling interval
+                                timeout=min((self.aw.qmc.delay/2000), self.timeout if self.timeout > 0 else 0.2) # the timeout should not be larger than half of the sampling interval
                                 )
                         self.readRetries = 1
                     except Exception: # pylint: disable=broad-except
@@ -284,7 +284,7 @@ class modbusport():
                             retry_on_invalid=False, # only supported for serial clients in v2.5.2
                             reset_socket=self.reset_socket,
                             retries=1,
-                            timeout=min((self.aw.qmc.delay/2000), self.timeout) # the timeout should not be larger than half of the sampling interval
+                            timeout=min((self.aw.qmc.delay/2000), self.timeout if self.timeout > 0 else 0.2) # the timeout should not be larger than half of the sampling interval
                             )
                         self.readRetries = 1
                     except Exception: # pylint: disable=broad-except # older versions of pymodbus don't support the retries, timeout nor the retry_on_empty arguments


### PR DESCRIPTION
I'm implementing a client device for Artisan as a ModbusTCP slave and sometimes my device doesn't respond quite fast enough for Artisan, as its read timeout is fixed to be min(0.2s, samplingtime/2) - so basically always 200ms. Setting the timeout to something like 0.5s fixes this problem for me and communication works well with fewer interruptions.

Allowing the timeout for ModbusTCP to be set from the "Config>Port" dialog would fully solve my problem. The timeout field that is there is currently only used for SerialModbus connections, but could be used for the same purpose without the need to change anything else.