### PR TITLE
Allow use of Aillio R1 winusb driver

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,9 +82,7 @@ for:
 
     # pull library versions from requirments file
     - ps: $env:PYINSTALLER_VER = Select-String -Path ./src/requirements.txt "pyinstaller==([\d\.]*).*platform_system='Windows'" -List | ForEach-Object {$_.Matches.Groups[1].Value}
-    - ps: $env:LIBUSB_VER = Select-String -Path ./src/requirements.txt "libusb==([\d\.]*).*platform_system='Windows'" -List | ForEach-Object {$_.Matches.Groups[1].Value}
     - ps: Write-Host "PYINSTALLER_VER= $env:PYINSTALLER_VER"
-    - ps: Write-Host "LIBUSB_VER= $env:LIBUSB_VER"
 
     # update path env var
     - cmd: set PATH=%PYTHON_PATH%;%PYTHON_PATH%\Scripts;%PATH%
@@ -151,9 +149,7 @@ for:
 
     # pull library versions from requirments file
     - ps: $env:PYINSTALLER_VER = Select-String -Path ./src/requirements.txt "pyinstaller==([\d\.]*).*platform_system='Windows'" -List | ForEach-Object {$_.Matches.Groups[1].Value}
-    - ps: $env:LIBUSB_VER = Select-String -Path ./src/requirements.txt "libusb==([\d\.]*).*platform_system='Windows'" -List | ForEach-Object {$_.Matches.Groups[1].Value}
     - ps: Write-Host "PYINSTALLER_VER= $env:PYINSTALLER_VER"
-    - ps: Write-Host "LIBUSB_VER= $env:LIBUSB_VER"
 
     # update path env var
     - cmd: set PATH=%PYTHON_PATH%;%PYTHON_PATH%\Scripts;%PATH%

--- a/.ci/install-win.bat
+++ b/.ci/install-win.bat
@@ -94,16 +94,6 @@ copy "%PYTHON_PATH%\Lib\site-packages\snap7\lib\snap7.dll" "C:\Windows"
 if not exist "C:\Windows\snap7.dll" (exit /b 150)
 
 ::
-:: download and copy the libusb-win32 dll. NOTE-the version number for libusb is set in the requirements-win*.txt file.
-::
-echo curl libusb-win32
-curl -k -L -O https://netcologne.dl.sourceforge.net/project/libusb-win32/libusb-win32-releases/%LIBUSB_VER%/libusb-win32-bin-%LIBUSB_VER%.zip
-if not exist libusb-win32-bin-%LIBUSB_VER%.zip (exit /b 160)
-7z x libusb-win32-bin-%LIBUSB_VER%.zip
-copy "libusb-win32-bin-%LIBUSB_VER%\bin\amd64\libusb0.dll" "C:\Windows\SysWOW64"
-if not exist "C:\Windows\SysWOW64\libusb0.dll" (exit /b 170)
-
-::
 :: show set of libraries are installed
 ::
 echo **** pip freeze ****

--- a/src/artisan-win.spec
+++ b/src/artisan-win.spec
@@ -99,7 +99,6 @@ PYQT_QT_BIN = PYQT_QT + r'\bin'
 PYQT_QT_TRANSLATIONS = QT_TRANSL
 YOCTO_BIN = PYTHON_PACKAGES + r'\yoctopuce\cdll'
 SNAP7_BIN = r'C:\Windows'
-LIBUSB_BIN = r'C:\Windows\SysWOW64'
 
 from PyInstaller.utils.hooks import is_module_satisfies
 if is_module_satisfies('scipy >= 1.3.2'):
@@ -232,10 +231,6 @@ copy_file(YOCTO_BIN + r'\yapi64.dll', TARGET + '_internal\yoctopuce\cdll')
 
 # copy Snap7 lib
 copy_file(SNAP7_BIN + r'\snap7.dll', TARGET)
-
-# copy libusb0.1 lib
-
-copy_file(LIBUSB_BIN + r'\libusb0.dll', TARGET + '_internal')
 
 for fn in [
     'artisan.png',

--- a/src/artisanlib/aillio.py
+++ b/src/artisanlib/aillio.py
@@ -26,6 +26,9 @@ import usb.util # type: ignore
 
 import array
 
+if system().startswith('Windows'):
+    import libusb_package  # pylint: disable=import-error
+
 #import requests
 #from requests_file import FileAdapter # type: ignore # @UnresolvedImport
 #import json
@@ -124,11 +127,18 @@ class AillioR1:
             return
         if self.usbhandle is not None:
             return
-        self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
-                                       idProduct=self.AILLIO_PID)
-        if self.usbhandle is None:
+        if not system().startswith('Windows'):
             self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
-                                           idProduct=self.AILLIO_PID_REV3)
+                                           idProduct=self.AILLIO_PID)
+            if self.usbhandle is None:
+                self.usbhandle = usb.core.find(idVendor=self.AILLIO_VID,
+                                               idProduct=self.AILLIO_PID_REV3)
+        else:
+            self.usbhandle = libusb_package.find(idVendor=self.AILLIO_VID,
+                                                 idProduct=self.AILLIO_PID)
+            if self.usbhandle is None:
+                self.usbhandle = libusb_package.find(idVendor=self.AILLIO_VID,
+                                                     idProduct=self.AILLIO_PID_REV3)
         if self.usbhandle is None:
             raise OSError('not found or no permission')
         self.__dbg('device found!')

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -275,7 +275,7 @@ no_implicit_optional = true
 plugins = ["numpy.typing.mypy_plugin"]
 
 [[tool.mypy.overrides]]
-module = ["matplotlib.*", "aiohttp.*", "aiohttp.web.*", "aiohttp_jinja2.*"]
+module = ["matplotlib.*", "aiohttp.*", "aiohttp.web.*", "aiohttp_jinja2.*", "libusb_package.*"]
 ignore_missing_imports = true
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,7 +20,6 @@
 # the following commented package versions are read by appveyor.yml and downloaded outside of pip.
 #
 # pyinstaller==6.3.0; platform_system='Windows'
-# libusb==1.2.7.3; platform_system='Windows'  #1.2.6.0
 # libusb==1.0.26;  platform_system='Linux'
 #
 # HACK: temporary require an older version of Pillow (PIL) as the current v10.0.0 breaks py2app on macOS
@@ -117,3 +116,4 @@ SecretStorage==3.3.3; platform_system=='Linux'
 build==1.0.3; platform_system=='Windows'  # required to build pyinstaller bootloader
 pywin32==306; platform_system=='Windows'
 pyinstaller-versionfile==2.1.1; platform_system=='Windows'
+libusb-package==1.0.26.2; platform_system=='Windows'


### PR DESCRIPTION
Changes windows to use libusb_package which includes the required dlls to allow artisan to connect to R1 without any modification of drivers

Resolves #549 