### PR TITLE
basic phidget stepper motor support for slider and buttons

### DIFF
--- a/src/artisanlib/canvas.py
+++ b/src/artisanlib/canvas.py
@@ -12528,6 +12528,8 @@ class tgraphcanvas(FigureCanvas):
         self.aw.ser.phidgetDCMotorClose()
         # close Phidget RC Servos
         self.aw.ser.phidgetRCclose()
+        # close Phidget Stepper Motors
+        self.aw.ser.phidgetStepperClose()
         # close Yocto Voltage Outputs
         self.aw.ser.yoctoVOUTclose()
         # close Yocto Current Outputs

--- a/src/artisanlib/comm.py
+++ b/src/artisanlib/comm.py
@@ -5240,9 +5240,6 @@ class serialport:
         except Exception: # pylint: disable=broad-except
             pass
 
-    def phidgetPrinter(self, channel:int, value:int, serial:Optional[str]=None) -> None:
-        print(f'channel:{channel}, value:{value}, serial:{serial}\n')
-
     # sets rescalefactor
     def phidgetStepperRescale(self, channel:int, value:int, serial:Optional[str]=None) -> None:
 

--- a/src/artisanlib/comm.py
+++ b/src/artisanlib/comm.py
@@ -5242,7 +5242,6 @@ class serialport:
 
     # sets rescalefactor
     def phidgetStepperRescale(self, channel:int, value:int, serial:Optional[str]=None) -> None:
-
         _log.debug('phidgetStepperRescale(%s,%s,%s,%s)',channel,value,serial)
         self.phidgetStepperAttach(channel,serial)
         if serial in self.aw.ser.PhidgetStepperMotor and len(self.aw.ser.PhidgetStepperMotor[serial])>channel:
@@ -5250,7 +5249,6 @@ class serialport:
 
     # sets position
     def phidgetStepperSet(self, channel:int, value:int, serial:Optional[str]=None) -> None:
-        
         _log.debug('phidgetStepperSet(%s,%s,%s,%s)',channel,value,serial)
         self.phidgetStepperAttach(channel,serial)
         if serial in self.aw.ser.PhidgetStepperMotor and len(self.aw.ser.PhidgetStepperMotor[serial])>channel:
@@ -5258,14 +5256,12 @@ class serialport:
 
     # engages channel
     def phidgetStepperEngaged(self, channel:int, state:bool, serial:Optional[str]=None) -> None:
-        #print('engage\n')
         _log.debug('phidgetStepperEngaged(%s,%s,%s,%s)',channel,state,serial)
         self.phidgetStepperAttach(channel,serial)
         if serial in self.aw.ser.PhidgetStepperMotor and len(self.aw.ser.PhidgetStepperMotor[serial])>channel:
             self.aw.ser.PhidgetStepperMotor[serial][channel].setEngaged(state)
 
     def phidgetStepperClose(self) -> None:
-        print('closing stepper\n')
         _log.debug('phidgetStepperClose')
         for c in self.aw.ser.PhidgetStepperMotor:
             st = self.aw.ser.PhidgetStepperMotor[c]

--- a/src/artisanlib/events.py
+++ b/src/artisanlib/events.py
@@ -127,7 +127,8 @@ class EventsDlg(ArtisanResizeablDialog):
                                      QApplication.translate('ComboBox','Aillio R1 Command'),
                                      QApplication.translate('ComboBox','Artisan Command'),
                                      QApplication.translate('ComboBox','RC Command'),
-                                     QApplication.translate('ComboBox','WebSocket Command')]
+                                     QApplication.translate('ComboBox','WebSocket Command'),
+                                     QApplication.translate('ComboBox','Stepper Command')]
         self.custom_button_actions_sorted:List[str] = sorted(self.custom_button_actions)
 
         titlefont = QFont()
@@ -774,7 +775,8 @@ class EventsDlg(ArtisanResizeablDialog):
                        QApplication.translate('ComboBox', 'Aillio R1 Drum'),
                        QApplication.translate('ComboBox', 'Artisan Command'),
                        QApplication.translate('ComboBox', 'RC Command'),
-                       QApplication.translate('ComboBox', 'WebSocket Command')]
+                       QApplication.translate('ComboBox', 'WebSocket Command'),
+                       QApplication.translate('ComboBox', 'Stepper Command')]
         self.sliderActionTypesSorted = sorted(self.sliderActionTypes)
         self.E1action = QComboBox()
         self.E1action.setToolTip(QApplication.translate('Tooltip', 'Action Type'))

--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -10242,6 +10242,57 @@ class ApplicationWindow(QMainWindow):  # pyright: ignore [reportGeneralTypeIssue
                         else:
                             # command not recognized
                             _log.info('WebSocket Command <%s> not recognized', cs)
+                elif action == 23:
+                    # PHIDGETS   sn : has the form <hub_serial>[:<hub_port>], an optional serial number of the hub, optionally specifying the port number the module is connected to
+                    ##  rescale(ch,rs,[,sn]) : sets the rescaleFactor
+                    ##  engaged(ch,b[,sn])   : engage (b=1) or disengage (b = 0)
+                    ##  set(ch,pos[,sn])     : set the target position
+                    if cmd_str:
+                        cmds = filter(None, cmd_str.split(';')) # allows for sequences of commands like in "<cmd>;<cmd>;...;<cmd>"
+                        for c in cmds:
+                            cs = c.strip()
+                            # rescale(ch,val[,sn]) # sets rescaleFactor
+                            if cs.startswith('rescale(') and len(cs) > 11:
+                                try:
+                                    n = 2
+                                    cs_split = cs[len('rescale('):-1].split(',')
+                                    channel_str,value = cs_split[0:n]
+                                    if len(cs_split)>n:
+                                        sn = cs_split[n]
+                                    else:
+                                        sn = None
+                                    self.ser.phidgetStepperRescale(int(channel_str),toFloat(eval(value)),sn) # pylint: disable=eval-used
+                                except Exception as e: # pylint: disable=broad-except
+                                    _log.exception(e)
+                            # engaged(ch,state[,sn]) # engage channel
+                            elif cs.startswith('engaged(') and len(cs) > 11:
+                                try:
+                                    n = 2
+                                    cs_split = cs[len('engaged('):-1].split(',')
+                                    channel_str, state_str = cs_split[0:n]
+                                    if len(cs_split)>n:
+                                        sn = cs_split[n]
+                                    else:
+                                        sn = None
+                                    state_engaged:bool = bool(state_str.lower() in {'yes', 'true', 't', '1'})
+                                    self.ser.phidgetStepperEngaged(int(channel_str), state_engaged, sn)
+                                except Exception as e: # pylint: disable=broad-except
+                                    _log.exception(e)
+                            # set(ch,pos[,sn]) # set position
+                            elif cs.startswith('set(') and len(cs) > 7:
+                                try:
+                                    n = 2
+                                    cs_split = cs[len('set('):-1].split(',')
+                                    channel_str,pos = cs_split[0:n]
+                                    if len(cs_split)>n:
+                                        sn = cs_split[n]
+                                    else:
+                                        sn = None
+                                    self.ser.phidgetStepperSet(int(channel_str),toFloat(eval(pos)),sn) # pylint: disable=eval-used
+                                except Exception as e: # pylint: disable=broad-except
+                                    _log.exception(e)
+                            else:
+                                _log.info('Stepper Command <%s> not recognized', cs)
             except Exception as e: # pylint: disable=broad-except
                 _log.exception(e)
 


### PR DESCRIPTION
Hello,

I added basic commands to control a phidget (bipolar-) stepper motor via a slider or button action.
I copied the structure of the phidget RC servo implementation.
Currently there are 3 commands:

rescale(ch,val[,sn]) - used to set the rescale factor
engaged(ch,state[,sn]) - used to engage the channel
set(ch,pos[,sn]) - used to set the target position

The (scale) 'Factor' in the Events-window can be used to decide the direction (-1 for counter-/ 1 for clockwise).
In combination with the 3 commands and the min/ max of the slider there are many ways to control the stepper motor.
The rescale factor can be used to make 1 step = 1° or 1 step = rotation, etc. 
So setting the min=0, max=100 and factor=-3.6 in combination with the right rescale factor gives a rotation in [0,-360°] where each step is equal to -3.6°.