### PR TITLE
Settings default file suffix aset

### DIFF
--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -24448,7 +24448,6 @@ class ApplicationWindow(QMainWindow):  # pyright: ignore [reportGeneralTypeIssue
         path = QDir()
         path.setPath(self.getDefaultPath())
         fname = path.absoluteFilePath(QApplication.translate('Message','artisan-settings'))
-        fname = fname + '.aset' if not fname.endswith('.aset') else fname
         filename = self.ArtisanSaveFileDialog(msg=QApplication.translate('Message', 'Save Settings'), path=fname, ext='*.aset')
         if filename:
             self.settingspath = filename

--- a/src/artisanlib/main.py
+++ b/src/artisanlib/main.py
@@ -24442,6 +24442,7 @@ class ApplicationWindow(QMainWindow):  # pyright: ignore [reportGeneralTypeIssue
         path = QDir()
         path.setPath(self.getDefaultPath())
         fname = path.absoluteFilePath(QApplication.translate('Message','artisan-settings'))
+        fname = fname + '.aset' if not fname.endswith('.aset') else fname
         filename = self.ArtisanSaveFileDialog(msg=QApplication.translate('Message', 'Save Settings'), path=fname, ext='*.aset')
         if filename:
             self.settingspath = filename

--- a/src/plus/schedule.py
+++ b/src/plus/schedule.py
@@ -4009,8 +4009,8 @@ class GreenWebDisplay(GreenDisplay):
                 # showing what is missing per component
                 # weight is rendered with max 7 characters ('10.32kg' is well displayed, '10.321kg' not) thus we set brief=1 for weights >= 10kg
                 delta_weight = component_target - current_weight
-                self.rendered_task['weight'] = f"{'+' if delta_weight<0 else ''}{render_weight(-delta_weight, 0, weight_units.index(self.schedule_window.aw.qmc.weight[2]),
-                            brief=(0 if delta_weight < 10000 else 1))}"
+                self.rendered_task['weight'] = f"""{'+' if delta_weight<0 else ''}{render_weight(-delta_weight, 0, weight_units.index(self.schedule_window.aw.qmc.weight[2]),
+                            brief=(0 if delta_weight < 10000 else 1))}"""
                 component_target_weight = target * current_component_ratio
                 completed_weight = target * completed_ratio
                 if component_target_weight>0:

--- a/src/plus/schedule.py
+++ b/src/plus/schedule.py
@@ -4009,8 +4009,8 @@ class GreenWebDisplay(GreenDisplay):
                 # showing what is missing per component
                 # weight is rendered with max 7 characters ('10.32kg' is well displayed, '10.321kg' not) thus we set brief=1 for weights >= 10kg
                 delta_weight = component_target - current_weight
-                self.rendered_task['weight'] = f"""{'+' if delta_weight<0 else ''}{render_weight(-delta_weight, 0, weight_units.index(self.schedule_window.aw.qmc.weight[2]),
-                            brief=(0 if delta_weight < 10000 else 1))}"""
+                self.rendered_task['weight'] = f"{'+' if delta_weight<0 else ''}{render_weight(-delta_weight, 0, weight_units.index(self.schedule_window.aw.qmc.weight[2]),
+                            brief=(0 if delta_weight < 10000 else 1))}"
                 component_target_weight = target * current_component_ratio
                 completed_weight = target * completed_ratio
                 if component_target_weight>0:


### PR DESCRIPTION
Include the filename extension ".aset" when saving the settings file.
This allows the file to appear again when loading, otherwise it is filtered when missing the extension.