### PR TITLE
Fixed TA612C device to use C or F configuration of the GUI.

### DIFF
--- a/src/artisanlib/comm.py
+++ b/src/artisanlib/comm.py
@@ -3221,7 +3221,11 @@ class serialport:
                     temperatures = struct.unpack('<HHHH', temperature_data)  # Assuming 4 channels of 16-bit data
 
                     # Convert raw temperature values to Celsius
-                    T1,T2,T3,T4 = ((temp / 10.0) for temp in temperatures)  # Divide by 10 to get the correct Celsius value
+                    # T1,T2,T3,T4 = ((temp / 10.0) for temp in temperatures)  # Divide by 10 to get the correct Celsius value
+                    if self.aw.qmc.mode == 'F':
+                        T1,T2,T3,T4 = (((temp / 10) * 9/5) + 32 for temp in temperatures)  # Get the correct Fahrenheit value
+                    else:
+                        T1,T2,T3,T4 = ((temp / 10) for temp in temperatures)  # Divide by 10 to get the correct Celsius value                        
 
                     self.aw.qmc.extraTASI_TA612C_T3 = T3
                     self.aw.qmc.extraTASI_TA612C_T4 = T4


### PR DESCRIPTION
Fixed temperature display for TA612C: the code now respects the GUI’s Celsius/Fahrenheit configuration instead of always showing Celsius.