### PR TITLE
Fix loadpoints open file mode

### DIFF
--- a/src/artisanlib/canvas.py
+++ b/src/artisanlib/canvas.py
@@ -17391,7 +17391,7 @@ class tgraphcanvas(FigureCanvas):
             filename = self.aw.ArtisanOpenFileDialog(msg=QApplication.translate('Message', 'Load Points'),ext='*.adsg')
             obj = None
             if os.path.exists(filename):
-                with open(filename, 'rb', encoding='utf-8') as f:
+                with open(filename, 'r', encoding='utf-8') as f:
                     obj=ast.literal_eval(f.read())
             if obj and 'timex' in obj and 'temp1' in obj and 'temp2' in obj:
                 self.timex = obj['timex']


### PR DESCRIPTION
This PR fixes what appears to be a bug in the designer `loadpoints` method (on macOS using the latest build):

<img width="1076" height="44" alt="image" src="https://github.com/user-attachments/assets/59244d11-9bf4-48e5-b399-169572b6e9af" />

`savepoints` opens with `w` and the downstream processing suggest text, so the fix is to replace `'rb'` with `'r'`, preserving the encoding as `utf-8`

Oddly enough, the [docs for `open`](https://docs.python.org/3/library/functions.html#open) don't disallow binary open with encoding:

> encoding is the name of the encoding used to decode or encode the file. This should only be used in text mode. [...]