### PR TITLE
first pass at improving bulgarian translations

### DIFF
--- a/src/translations/artisan_bg.ts
+++ b/src/translations/artisan_bg.ts
@@ -74,7 +74,7 @@
         <location filename="../artisanlib/canvas.py" line="11944" />
         <location filename="../artisanlib/statistics.py" line="198" />
         <source>Roast of the Day</source>
-        <translation>Печено на деня</translation>
+        <translation>Печене на деня</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="12021" />
@@ -102,19 +102,19 @@
         <location filename="../artisanlib/canvas.py" line="12047" />
         <location filename="../artisanlib/statistics.py" line="207" />
         <source>Density Roasted</source>
-        <translation>Плътност на печене</translation>
+        <translation>Плътност на изпеченото кафе</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="12051" />
         <location filename="../artisanlib/statistics.py" line="208" />
         <source>Moisture Roasted</source>
-        <translation>Печено на влага</translation>
+        <translation>Влажност на изпеченото кафе</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="12055" />
         <location filename="../artisanlib/statistics.py" line="209" />
         <source>Ground Color</source>
-        <translation>Цвят на основата</translation>
+        <translation>Цвят на смляното кафе</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="12059" />
@@ -138,7 +138,7 @@
         <location filename="../artisanlib/canvas.py" line="12101" />
         <location filename="../artisanlib/statistics.py" line="218" />
         <source>Weight Loss</source>
-        <translation>Отслабване</translation>
+        <translation>Загуба на тегло</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="11984" />
@@ -168,7 +168,7 @@
     <message>
         <location filename="../artisanlib/canvas.py" line="12168" />
         <source>Yield</source>
-        <translation>Доходност</translation>
+        <translation>Добив</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="12174" />
@@ -253,7 +253,7 @@
     <message>
         <location filename="../artisanlib/wheels.py" line="136" />
         <source>Open</source>
-        <translation>Отворено</translation>
+        <translation>Отвори</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="292" />
@@ -298,7 +298,7 @@
         <location filename="../artisanlib/pid_dialogs.py" line="450" />
         <location filename="../artisanlib/pid_dialogs.py" line="299" />
         <source>Set</source>
-        <translation>Комплект</translation>
+        <translation>Задай</translation>
     </message>
     <message>
         <location filename="../artisanlib/alarms.py" line="100" />
@@ -365,27 +365,27 @@
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1955" />
         <source>Write SV</source>
-        <translation>Напишете SV</translation>
+        <translation>Запиши SV</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1966" />
         <source>Read SV</source>
-        <translation>Прочетете SV</translation>
+        <translation>Прочети SV</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1981" />
         <source>Set p</source>
-        <translation>Задайте p</translation>
+        <translation>Задай p</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1983" />
         <source>Set i</source>
-        <translation>Комплект i</translation>
+        <translation>Задай i</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1985" />
         <source>Set d</source>
-        <translation>Комплект d</translation>
+        <translation>Задай d</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="3099" />
@@ -411,7 +411,7 @@
         <location filename="../artisanlib/pid_dialogs.py" line="2035" />
         <location filename="../artisanlib/pid_dialogs.py" line="2033" />
         <source>Read</source>
-        <translation>Прочетете</translation>
+        <translation>Прочети</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="3167" />
@@ -443,47 +443,47 @@
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2886" />
         <source>Write SV1</source>
-        <translation>Напишете SV1</translation>
+        <translation>Запиши SV1</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2888" />
         <source>Write SV2</source>
-        <translation>Напишете SV2</translation>
+        <translation>Запиши SV2</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2890" />
         <source>Write SV3</source>
-        <translation>Напишете SV3</translation>
+        <translation>Запиши SV3</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2892" />
         <source>Write SV4</source>
-        <translation>Напишете SV4</translation>
+        <translation>Запиши SV4</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2894" />
         <source>Write SV5</source>
-        <translation>Напишете SV5</translation>
+        <translation>Запиши SV5</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2896" />
         <source>Write SV6</source>
-        <translation>Напишете SV6</translation>
+        <translation>Запиши SV6</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2898" />
         <source>Write SV7</source>
-        <translation>Напишете SV7</translation>
+        <translation>Запиши SV7</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2977" />
         <source>Read SV (7-0)</source>
-        <translation>Прочетете SV (7-0)</translation>
+        <translation>Прочети SV (7-0)</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2979" />
         <source>Write SV (7-0)</source>
-        <translation>Напишете SV (7-0)</translation>
+        <translation>Запиши SV (7-0)</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="3081" />
@@ -538,7 +538,7 @@
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="4769" />
         <source>Write</source>
-        <translation>Пишете</translation>
+        <translation>Запиши</translation>
     </message>
     <message>
         <location filename="../artisanlib/transposer.py" line="137" />
@@ -588,7 +588,7 @@
     <message>
         <location filename="../artisanlib/events.py" line="700" />
         <source>&lt;&lt; Store Palette</source>
-        <translation>&lt;&lt; Палитра на магазина</translation>
+        <translation>&lt;&lt; Съхрани палитра</translation>
     </message>
     <message>
         <location filename="../artisanlib/events.py" line="702" />
@@ -719,7 +719,7 @@
     <message>
         <location filename="../artisanlib/curves.py" line="836" />
         <source>Plot</source>
-        <translation>Сюжет</translation>
+        <translation>Начертай</translation>
     </message>
     <message>
         <location filename="../artisanlib/curves.py" line="839" />
@@ -738,7 +738,7 @@
         <location filename="../artisanlib/colors.py" line="125" />
         <location filename="../artisanlib/curves.py" line="843" />
         <source>Background</source>
-        <translation>Предистория</translation>
+        <translation>Фон</translation>
     </message>
     <message>
         <location filename="../artisanlib/cup_profile.py" line="101" />
@@ -849,12 +849,12 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="3282" />
         <source>CHARGE</source>
-        <translation>ЗАРАЖДАНЕ</translation>
+        <translation>ЗАРЯД</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3287" />
         <source>DROP</source>
-        <translation>КАПАНЕ</translation>
+        <translation>ИЗСИПВАНЕ</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3292" />
@@ -900,15 +900,13 @@ END</source>
         <location filename="../artisanlib/main.py" line="3366" />
         <source>DRY
 END</source>
-        <translation>СУХО
-КРАЙ</translation>
+        <translation>КРАЙ НА СУШЕНЕТО</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3371" />
         <source>COOL
 END</source>
-        <translation>ГОТИНО
-КРАЙ</translation>
+        <translation>КРАЙ НА ОХЛАЖДАНЕТО</translation>
     </message>
     <message>
         <location filename="../artisanlib/transposer.py" line="134" />
@@ -939,7 +937,7 @@ END</source>
         <location filename="../artisanlib/colors.py" line="155" />
         <location filename="../artisanlib/canvas.py" line="12135" />
         <source>Maillard Phase</source>
-        <translation>Фаза на Майлар</translation>
+        <translation>Фаза на Майяр</translation>
     </message>
     <message>
         <location filename="../artisanlib/colors.py" line="150" />
@@ -959,7 +957,7 @@ END</source>
         <location filename="../artisanlib/colors.py" line="67" />
         <location filename="../artisanlib/colors.py" line="57" />
         <source>ET</source>
-        <translation>Източно време</translation>
+        <translation>ET</translation>
     </message>
     <message>
         <location filename="../artisanlib/colors.py" line="93" />
@@ -1072,7 +1070,7 @@ END</source>
     <message>
         <location filename="../artisanlib/colors.py" line="257" />
         <source>MET Text</source>
-        <translation>Текст за ТРЕТИРАНИ ОБЕКТИ</translation>
+        <translation>MET текст</translation>
     </message>
     <message>
         <location filename="../artisanlib/colors.py" line="262" />
@@ -1162,7 +1160,7 @@ END</source>
         <location filename="../artisanlib/comm.py" line="193" />
         <location filename="../artisanlib/axis.py" line="266" />
         <source>ET</source>
-        <translation>Източно време</translation>
+        <translation>ET</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="89" />
@@ -1303,12 +1301,12 @@ END</source>
     <message>
         <location filename="../artisanlib/ports.py" line="267" />
         <source>Int</source>
-        <translation>Международен</translation>
+        <translation>Цяло число</translation>
     </message>
     <message>
         <location filename="../artisanlib/ports.py" line="270" />
         <source>Float</source>
-        <translation>Плуване</translation>
+        <translation>Дробно число</translation>
     </message>
     <message>
         <location filename="../artisanlib/ports.py" line="1378" />
@@ -1410,13 +1408,13 @@ END</source>
         <location filename="../artisanlib/main.py" line="23932" />
         <location filename="../artisanlib/roast_properties.py" line="1201" />
         <source>Drops</source>
-        <translation>Капки</translation>
+        <translation>Изсипване</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23934" />
         <location filename="../artisanlib/roast_properties.py" line="1204" />
         <source>Oily</source>
-        <translation>Мазна</translation>
+        <translation>Мазни зърна</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23936" />
@@ -1428,19 +1426,19 @@ END</source>
         <location filename="../artisanlib/main.py" line="23938" />
         <location filename="../artisanlib/roast_properties.py" line="1209" />
         <source>Tipping</source>
-        <translation>Бакшиш</translation>
+        <translation>Обгаряне на върховете</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23940" />
         <location filename="../artisanlib/roast_properties.py" line="1211" />
         <source>Scorching</source>
-        <translation>Парещо</translation>
+        <translation>Изгаряне</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23942" />
         <location filename="../artisanlib/roast_properties.py" line="1213" />
         <source>Divots</source>
-        <translation>Дивоти</translation>
+        <translation>Вдлъбнатини</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1418" />
@@ -1510,7 +1508,7 @@ END</source>
     <message>
         <location filename="../artisanlib/curves.py" line="418" />
         <source>Drop Spikes</source>
-        <translation>Капка шипове</translation>
+        <translation>Изсипване на шипове</translation>
     </message>
     <message>
         <location filename="../artisanlib/curves.py" line="647" />
@@ -1560,7 +1558,7 @@ END</source>
     <message>
         <location filename="../artisanlib/statistics.py" line="59" />
         <source>Bar</source>
-        <translation>Бар</translation>
+        <translation>Лента</translation>
     </message>
     <message>
         <location filename="../artisanlib/statistics.py" line="67" />
@@ -1581,7 +1579,7 @@ END</source>
         <location filename="../artisanlib/cup_profile.py" line="109" />
         <location filename="../artisanlib/statistics.py" line="131" />
         <source>Background</source>
-        <translation>Предистория</translation>
+        <translation>Фон</translation>
     </message>
     <message>
         <location filename="../artisanlib/statistics.py" line="136" />
@@ -1694,7 +1692,7 @@ END</source>
         <location filename="../artisanlib/comparator.py" line="994" />
         <location filename="../artisanlib/axis.py" line="193" />
         <source>Roast</source>
-        <translation>Печено</translation>
+        <translation>Печене</translation>
     </message>
     <message>
         <location filename="../artisanlib/comparator.py" line="995" />
@@ -2102,7 +2100,7 @@ END</source>
         <location filename="../artisanlib/curves.py" line="2247" />
         <location filename="../artisanlib/events.py" line="1109" />
         <source>ET</source>
-        <translation>Източно време</translation>
+        <translation>ET</translation>
     </message>
     <message>
         <location filename="../artisanlib/curves.py" line="2248" />
@@ -4421,7 +4419,7 @@ END</source>
     <message>
         <location filename="../artisanlib/axis.py" line="70" />
         <source>Axes</source>
-        <translation>Брадви</translation>
+        <translation>Оси</translation>
     </message>
     <message>
         <location filename="../artisanlib/wheels.py" line="41" />
@@ -4762,12 +4760,12 @@ END</source>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="606" />
         <source>Clamp</source>
-        <translation>Скоба</translation>
+        <translation>Ограничение</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="621" />
         <source>Duty</source>
-        <translation>Мито</translation>
+        <translation>Работен цикъл</translation>
     </message>
     <message>
         <location filename="../artisanlib/events.py" line="1207" />
@@ -5209,7 +5207,7 @@ END</source>
         <location filename="../artisanlib/main.py" line="22053" />
         <location filename="../artisanlib/main.py" line="21858" />
         <source>Beans</source>
-        <translation>Боб</translation>
+        <translation>Зърна</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23202" />
@@ -5234,12 +5232,12 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="21862" />
         <source>Def.</source>
-        <translation>Защита.</translation>
+        <translation>Деф.</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="21863" />
         <source>Def.L</source>
-        <translation>Защита Л</translation>
+        <translation>Деф. Загуба</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22111" />
@@ -5329,7 +5327,7 @@ END</source>
         <location filename="../artisanlib/main.py" line="22371" />
         <location filename="../artisanlib/main.py" line="22309" />
         <source>Weight Loss</source>
-        <translation>Отслабване</translation>
+        <translation>Загуба на тегло</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23204" />
@@ -5340,12 +5338,12 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="22311" />
         <source>Cupping</source>
-        <translation>Вендузи</translation>
+        <translation>Каппинг</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22312" />
         <source>Roaster</source>
-        <translation>Пекарна</translation>
+        <translation>Ростер</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22313" />
@@ -5555,7 +5553,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="22360" />
         <source>Total RoR</source>
-        <translation>Обща възвръщаемост на риска</translation>
+        <translation>Общ RoR</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22361" />
@@ -5595,7 +5593,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="22370" />
         <source>Weight Out</source>
-        <translation>Отслабване</translation>
+        <translation>Изходно тегло</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22372" />
@@ -5640,7 +5638,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="22380" />
         <source>Moisture Roasted</source>
-        <translation>Печено на влага</translation>
+        <translation>Влажност след печене</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22381" />
@@ -5677,7 +5675,7 @@ END</source>
         <location filename="../artisanlib/main.py" line="23884" />
         <location filename="../artisanlib/main.py" line="22388" />
         <source>Cupping Notes</source>
-        <translation>Бележки за вендузи</translation>
+        <translation>Бележки от каппинг</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="22389" />
@@ -5882,7 +5880,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="23806" />
         <source>Beans:</source>
-        <translation>Боб:</translation>
+        <translation>Зърна:</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23808" />
@@ -5897,7 +5895,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="23814" />
         <source>Roaster:</source>
-        <translation>Пекарна:</translation>
+        <translation>Ростер:</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23816" />
@@ -6038,7 +6036,7 @@ END</source>
     <message>
         <location filename="../artisanlib/main.py" line="23871" />
         <source>RoR:</source>
-        <translation>Доказателство за маршрут:</translation>
+        <translation>RoR:</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="23873" />
@@ -7721,7 +7719,7 @@ Hold Shift+Alt [Win]</source>
         <location filename="../help/keyboardshortcuts_help.py" line="119" />
         <location filename="../help/keyboardshortcuts_help.py" line="118" />
         <source>Roast</source>
-        <translation>Печено</translation>
+        <translation>Печене</translation>
     </message>
     <message>
         <location filename="../help/keyboardshortcuts_help.py" line="118" />
@@ -11368,7 +11366,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/roast_properties.py" line="897" />
         <location filename="../plus/blend.py" line="343" />
         <source>Beans</source>
-        <translation>Боб</translation>
+        <translation>Зърна</translation>
     </message>
     <message>
         <location filename="../artisanlib/statistics.py" line="231" />
@@ -11422,7 +11420,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/statistics.py" line="214" />
         <location filename="../plus/schedule.py" line="2131" />
         <source>Cupping Score</source>
-        <translation>Резултат от купинг</translation>
+        <translation>Оценка от каппинг</translation>
     </message>
     <message>
         <location filename="../artisanlib/statistics.py" line="215" />
@@ -11430,7 +11428,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../plus/schedule.py" line="2138" />
         <location filename="../plus/schedule.py" line="2137" />
         <source>Cupping Notes</source>
-        <translation>Бележки за вендузи</translation>
+        <translation>Бележки от каппинг</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="905" />
@@ -11547,7 +11545,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/wheels.py" line="447" />
         <source> dg</source>
-        <translation>генерален директор</translation>
+        <translation>°</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="18397" />
@@ -11610,7 +11608,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/events.py" line="293" />
         <location filename="../artisanlib/comparator.py" line="862" />
         <source>ET</source>
-        <translation>Източно време</translation>
+        <translation>ET</translation>
     </message>
     <message>
         <location filename="../artisanlib/comparator.py" line="894" />
@@ -11794,7 +11792,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="165" />
         <source>PV</source>
-        <translation>Фотоволтаична система</translation>
+        <translation>PV</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="8554" />
@@ -11906,7 +11904,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/main.py" line="6214" />
         <location filename="../artisanlib/pid_dialogs.py" line="458" />
         <source>Background</source>
-        <translation>Предистория</translation>
+        <translation>Фон</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="465" />
@@ -11946,7 +11944,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="654" />
         <source>PoE</source>
-        <translation>Поверителен сертификат за валидност</translation>
+        <translation>PoE</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="656" />
@@ -11956,7 +11954,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="659" />
         <source>DoE</source>
-        <translation>Министерство на природосъобразността</translation>
+        <translation>DoE</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="661" />
@@ -12102,7 +12100,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="1918" />
         <source>Ramp/Soak Pattern</source>
-        <translation>Модел на рампа/накисване</translation>
+        <translation>Шаблон за рампа/накисване</translation>
     </message>
     <message>
         <location filename="../artisanlib/pid_dialogs.py" line="2950" />
@@ -12328,7 +12326,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/canvas.py" line="16173" />
         <location filename="../artisanlib/events.py" line="603" />
         <source>MET</source>
-        <translation>ТРЕТИРАН ПЛАЩАНЕ</translation>
+        <translation>МЕТ</translation>
     </message>
     <message>
         <location filename="../artisanlib/events.py" line="631" />
@@ -12819,7 +12817,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1051" />
         <source>Screen</source>
-        <translation>Екран</translation>
+        <translation>Сито</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1070" />
@@ -12829,7 +12827,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1077" />
         <source>Ground</source>
-        <translation>Земя</translation>
+        <translation>Смляно</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1134" />
@@ -12845,7 +12843,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1362" />
         <source>Stock</source>
-        <translation>Запас</translation>
+        <translation>Наличност</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1364" />
@@ -12974,7 +12972,7 @@ Using math formulas in the plotter also allows to use the symbolic variables P a
         <location filename="../artisanlib/roast_properties.py" line="3594" />
         <location filename="../artisanlib/roast_properties.py" line="3589" />
         <source>Roast</source>
-        <translation>Печено</translation>
+        <translation>Печене</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="3632" />
@@ -13345,7 +13343,7 @@ LCD дисплеи Всички</translation>
     <message>
         <location filename="../artisanlib/statistics.py" line="200" />
         <source>Roaster</source>
-        <translation>Пекарна</translation>
+        <translation>Ростер</translation>
     </message>
     <message>
         <location filename="../artisanlib/statistics.py" line="228" />
@@ -13429,7 +13427,7 @@ Fewer nodes: simpler curve but may lose detail</source>
         <location filename="../artisanlib/main.py" line="3453" />
         <location filename="../artisanlib/large_lcds.py" line="579" />
         <source>PID SV</source>
-        <translation>ПИД променлив ток</translation>
+        <translation>ПИД зададена стойност</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3457" />
@@ -13561,7 +13559,7 @@ Fewer nodes: simpler curve but may lose detail</source>
     <message>
         <location filename="../artisanlib/main.py" line="6276" />
         <source>MET Text</source>
-        <translation>Текст за ТРЕТИРАНИ ОБЕКТИ</translation>
+        <translation>МЕТ Текст</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="6279" />
@@ -13795,7 +13793,7 @@ Fewer nodes: simpler curve but may lose detail</source>
         <location filename="../artisanlib/main.py" line="26633" />
         <location filename="../artisanlib/main.py" line="26621" />
         <source>MANUAL</source>
-        <translation>РЪКОВОДСТВО</translation>
+        <translation>РЪЧНО</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="26622" />
@@ -13839,7 +13837,7 @@ Fewer nodes: simpler curve but may lose detail</source>
     <message>
         <location filename="../artisanlib/main.py" line="26630" />
         <source>FILL</source>
-        <translation>ПОПЪЛНЕТЕ</translation>
+        <translation>ПЪЛНЕНЕ</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="26632" />
@@ -13909,7 +13907,7 @@ Fewer nodes: simpler curve but may lose detail</source>
     <message>
         <location filename="../artisanlib/devices.py" line="114" />
         <source>Logging</source>
-        <translation>Дърводобив</translation>
+        <translation>Протоколиране</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="117" />
@@ -13978,7 +13976,7 @@ Fewer nodes: simpler curve but may lose detail</source>
         <location filename="../artisanlib/devices.py" line="433" />
         <location filename="../artisanlib/devices.py" line="385" />
         <source>Rate</source>
-        <translation>Оцени</translation>
+        <translation>Скорост</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="1011" />
@@ -13989,7 +13987,7 @@ Fewer nodes: simpler curve but may lose detail</source>
     <message>
         <location filename="../artisanlib/devices.py" line="555" />
         <source>Gain</source>
-        <translation>Печалба</translation>
+        <translation>Усилване</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="715" />
@@ -14026,7 +14024,7 @@ Fewer nodes: simpler curve but may lose detail</source>
     <message>
         <location filename="../artisanlib/devices.py" line="1123" />
         <source>MASL</source>
-        <translation>МДС</translation>
+        <translation>MASL</translation>
     </message>
     <message>
         <location filename="../artisanlib/devices.py" line="1124" />
@@ -14670,7 +14668,7 @@ Fewer nodes: simpler curve but may lose detail</source>
         <location filename="../artisanlib/main.py" line="4410" />
         <location filename="../artisanlib/main.py" line="2384" />
         <source>Roast</source>
-        <translation>Печено</translation>
+        <translation>Печене</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="2421" />
@@ -16866,7 +16864,7 @@ It is advisable to save your current settings beforehand via menu Help &gt;&gt; 
     <message>
         <location filename="../artisanlib/main.py" line="25126" />
         <source>artisan-settings</source>
-        <translation>занаятчийски обстановки</translation>
+        <translation>artisan-настройки</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="25127" />
@@ -16881,7 +16879,7 @@ It is advisable to save your current settings beforehand via menu Help &gt;&gt; 
     <message>
         <location filename="../artisanlib/main.py" line="25193" />
         <source>artisan-theme</source>
-        <translation>занаятчийска тема</translation>
+        <translation>artisan-тема</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="25194" />
@@ -17456,7 +17454,7 @@ Correct this on the Config&gt;Curves&gt;Analyze tab.</source>
     <message>
         <location filename="../artisanlib/canvas.py" line="14664" />
         <source>CHARGE: Scope is not recording</source>
-        <translation>ЗАРЕЖДАНЕ: Телескопът не записва</translation>
+        <translation>ЗАРЯД: Осцилоскопът не записва</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="14689" />
@@ -17471,7 +17469,7 @@ Correct this on the Config&gt;Curves&gt;Analyze tab.</source>
     <message>
         <location filename="../artisanlib/canvas.py" line="14807" />
         <source>DRY END: Scope is not recording</source>
-        <translation>СУХ КРАЙ: Телескопът не записва</translation>
+        <translation>КРАЙ НА СУШЕНЕ: Осцилоскопът не записва</translation>
     </message>
     <message>
         <location filename="../artisanlib/canvas.py" line="14843" />
@@ -17739,7 +17737,7 @@ Profile missing [CHARGE] or [DROP]</source>
     <message>
         <location filename="../plus/stock.py" line="470" />
         <source>bag</source>
-        <translation>чанта</translation>
+        <translation>чувал</translation>
     </message>
     <message>
         <location filename="../plus/stock.py" line="471" />
@@ -17749,12 +17747,12 @@ Profile missing [CHARGE] or [DROP]</source>
     <message>
         <location filename="../plus/stock.py" line="472" />
         <source>barrel</source>
-        <translation>барел</translation>
+        <translation>бъчва</translation>
     </message>
     <message>
         <location filename="../plus/stock.py" line="475" />
         <source>bags</source>
-        <translation>чанти</translation>
+        <translation>чували</translation>
     </message>
     <message>
         <location filename="../plus/stock.py" line="476" />
@@ -18516,7 +18514,7 @@ Profile missing [CHARGE] or [DROP]</source>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1653" />
         <source>Roast</source>
-        <translation>Печено</translation>
+        <translation>Печене</translation>
     </message>
     <message>
         <location filename="../artisanlib/roast_properties.py" line="1656" />
@@ -19294,7 +19292,7 @@ Profile missing [CHARGE] or [DROP]</source>
     <message>
         <location filename="../artisanlib/main.py" line="748" />
         <source>Home</source>
-        <translation>Дом</translation>
+        <translation>Начало</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="749" />
@@ -19309,7 +19307,7 @@ Profile missing [CHARGE] or [DROP]</source>
     <message>
         <location filename="../artisanlib/main.py" line="752" />
         <source>Pan</source>
-        <translation>Тиган</translation>
+        <translation>Преместване</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="753" />
@@ -19973,7 +19971,7 @@ has to be reduced by 4 times.</source>
         <location filename="../artisanlib/events.py" line="1075" />
         <location filename="../artisanlib/events.py" line="1070" />
         <source>fire slider action</source>
-        <translation>действие на плъзгача за огън</translation>
+        <translation>задейства действието на плъзгача</translation>
     </message>
     <message>
         <location filename="../artisanlib/events.py" line="1105" />
@@ -20762,12 +20760,12 @@ Unchecked: Fits a smooth spline to preserve curve shape.</source>
     <message>
         <location filename="../artisanlib/main.py" line="3254" />
         <source>First Crack Start</source>
-        <translation>Първият старт на пукнатината</translation>
+        <translation>Начало на Първа пукнатина</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3258" />
         <source>First Crack End</source>
-        <translation>Първият край на пукнатината</translation>
+        <translation>Край на Първа пукнатина</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3262" />
@@ -20787,12 +20785,12 @@ Unchecked: Fits a smooth spline to preserve curve shape.</source>
     <message>
         <location filename="../artisanlib/main.py" line="3283" />
         <source>Charge</source>
-        <translation>Такса</translation>
+        <translation>Заряд</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3288" />
         <source>Drop</source>
-        <translation>Пуснете</translation>
+        <translation>Изсипване</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3306" />
@@ -20847,7 +20845,7 @@ Unchecked: Fits a smooth spline to preserve curve shape.</source>
     <message>
         <location filename="../artisanlib/main.py" line="3423" />
         <source>ET Temperature</source>
-        <translation>Източноевропейска температура</translation>
+        <translation>ET Температура</translation>
     </message>
     <message>
         <location filename="../artisanlib/main.py" line="3424" />


### PR DESCRIPTION
This PR contains a first round of ~100 Bulgarian translation improvements. There will be more corrections to follow, but these are the most important ones for now, as they fix the most relevant set of terms and correctly contextualize the translations to be relevant to the domains of coffee roasting and computer software.