### PR TITLE
Flathub trigger & version check

### DIFF
--- a/.github/workflows/flathub.yaml
+++ b/.github/workflows/flathub.yaml
@@ -1,0 +1,16 @@
+name: Trigger Flathub update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Flathub update workflow
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        repository: flathub/org.artisan_scope.artisan
+        event-type: trigger-workflow
+        token: ${{ secrets.TRIGGER_WORKFLOW_TOKEN }}

--- a/.github/workflows/metainfo.yaml
+++ b/.github/workflows/metainfo.yaml
@@ -1,0 +1,21 @@
+name: Check metainfo version
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          TAG_VERSION=`echo "${GITHUB_REF_NAME}" | sed 's/^v//'`
+          METAINFO_VERSION=`cat src/debian/usr/share/metainfo/org.artisan_scope.artisan.metainfo.xml | sed 's/^\s*<release.*version="\([^"]\+\)".*$/\1/p;d' | head -n1`
+          echo "tag: ${TAG_VERSION}"
+          echo "metainfo: ${METAINFO_VERSION}"
+          if [ "${TAG_VERSION}" != "${METAINFO_VERSION}" ]; then
+            echo "version from tag different from metainfo, please check you updated the metainfo file for this version tag" 1>&2
+            exit 1
+          fi


### PR DESCRIPTION
The [Flathub application source](https://github.com/flathub/org.artisan_scope.artisan) has just [moved to](https://github.com/flathub/org.artisan_scope.artisan/blob/master/.github/workflows/update.yaml) using Github Actions to create a new version with all the dependencies. This can be triggered automatically from this repository when a new release is published. [Flathub documentation on the trigger](https://docs.flathub.org/docs/for-app-authors/maintenance#custom-triggered-from-an-external-repository). The [dispatch action](https://github.com/peter-evans/repository-dispatch) needs a [token for access to both the Artisan and Flathub repository](https://github.com/peter-evans/repository-dispatch#token) (I would suggest a fine-grained access token).

And to make sure the metainfo file is updated on releasing a new version: a check when a new version tag is created.

I haven't ran the actions in practice on the repository, so it could be that something unexpected is encountered. But if it works, it will reduce time for maintainers of both Artisan and the Flatpak.